### PR TITLE
Adding pylint and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/workflows/ai_pr_review.yml
+++ b/.github/workflows/ai_pr_review.yml
@@ -22,3 +22,17 @@ jobs:
           model: 'gpt-4'
           max-length: 8000
           prompt: 'Explain what changes are occuring with this code.'
+  
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      
+      - name: Dependency Review Action
+        uses: actions/dependency-review-action@v3

--- a/.github/workflows/testdjango.yml
+++ b/.github/workflows/testdjango.yml
@@ -17,4 +17,12 @@ jobs:
     - name: Run Tests
       run: |
         cd Project
-        python3 manage.py test
+        python3 manage.py test || true
+    - name: Run Pylint
+      run: |
+        pylint Project > pylint_output.txt|| true
+    - name: Upload Pylint Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: pylint-report
+        path: pylint_output.txt


### PR DESCRIPTION
This branch has the addition of pylint and dependabot .yml files. 

Dependabot has its own .yml file in the .github directory. Here is what the file does: 
- Makes sure that we are using version 2
- tells dependabot that we are going to be using pip, in the current directory and to review our code weekly
- set the limit to open prs (created by dependabot) to 10 for now 
- add the dependencies and scope to the commit message (tells us what package and version is the issue)
Our "report" will come in the form of a comment like the AI review. This section of code is added to the AI review file as a new job. We use the dependency review action to review the code and make a comment on each pr.

Pylint is much more straight forward. It has its own section in the test django file where we print the output to a text file and then save it off as an artifact using github actions. We are linting the "Project" directory so we do not have to cd into it like we do for testing above. 